### PR TITLE
Fix several typos

### DIFF
--- a/qesource/extensions/sfext/addpol/STRIPPED_BIGLOOP.c
+++ b/qesource/extensions/sfext/addpol/STRIPPED_BIGLOOP.c
@@ -97,7 +97,7 @@ Return:/* Return. */
       tt = ACLOCK() - tt;
 
                     if (PCVERBOSE) {
-		    SWRITE("The whole thing took: "); IWRITE(tt); SWRITE(" miliseconds!\n\n"); }
+		    SWRITE("The whole thing took: "); IWRITE(tt); SWRITE(" milliseconds!\n\n"); }
 
       *P_ = P;
       *D_ = D;

--- a/qesource/source/qepcad.help
+++ b/qesource/source/qepcad.help
@@ -719,7 +719,7 @@ limit-entry-db 6 abcde m
 @
 limit-entry-db NNN
 
-Only when the actual computation took longer than NNN miliseconds,
+Only when the actual computation took longer than NNN milliseconds,
 its results are stored into a database.
 @
 

--- a/qesource/source/ticad/SUBST.c
+++ b/qesource/source/ticad/SUBST.c
@@ -53,7 +53,7 @@ Step2: /* Check if S1 vanishes and, if so, whether this invalidates McCallum's p
 		SWRITE(" in the cylinder ");
 		SWRITE("over the cell ");
 		LWRITE(LELTI(c,INDX));
-		SWRITE(" of postive dimension.  The McCallum projection ");
+		SWRITE(" of positive dimension.  The McCallum projection ");
 		SWRITE("may not be valid.\n"); }
 	    }
 	    if (f == TRUE || CELLDIM(c) == 0) {
@@ -65,7 +65,7 @@ Step2: /* Check if S1 vanishes and, if so, whether this invalidates McCallum's p
 		SWRITE(" in the cylinder \n");
 		SWRITE("over the cell ");
 		LWRITE(LELTI(c,INDX));
-		SWRITE(" of postive dimension.  The McCallum projection \n");
+		SWRITE(" of poistive dimension.  The McCallum projection \n");
 		SWRITE("may not be valid.\n");
 	      }
 	    }

--- a/qesource/source/ticad/SUBSTR.c
+++ b/qesource/source/ticad/SUBSTR.c
@@ -53,7 +53,7 @@ Step2: /* Check if S1 vanishes and, if so, whether this invalidates McCallum's p
 		 SWRITE(" in the cylinder ");
 		 SWRITE("over the cell ");
 		 LWRITE(LELTI(c,INDX));
-		 SWRITE(" of postive dimension.  The McCallum projection ");
+		 SWRITE(" of positive dimension.  The McCallum projection ");
 		 SWRITE("may not be valid.\n"); } }
 	     
 	     if (CELLDIM(c) == 0 || f == TRUE) {
@@ -65,7 +65,7 @@ Step2: /* Check if S1 vanishes and, if so, whether this invalidates McCallum's p
 		 SWRITE(" in the cylinder \n");
 		 SWRITE("over the cell ");
 		 LWRITE(LELTI(c,INDX));
-		 SWRITE(" of postive dimension.  The McCallum projection \n");
+		 SWRITE(" of positive dimension.  The McCallum projection \n");
 		 SWRITE("may not be valid.\n");
 	       }
 	     }


### PR DESCRIPTION
These were reported by Lintian as [spelling-error-in-binary](https://lintian.debian.org/tags/spelling-error-in-binary) warnings.