### PR TITLE
Use signed char when reading input.

### DIFF
--- a/qesource/extensions/rend/PLOT2DCAD2FILE.cc
+++ b/qesource/extensions/rend/PLOT2DCAD2FILE.cc
@@ -38,7 +38,7 @@ Step0: /* Read user input */
   bool 
     z = true, // show zero dimensional cell
     c = true; // make a plot in color
-  char g;
+  signed char g;
   while((g = lin.get()) && g != EOF) {
     switch(g) {
     case 'z': z = false; break;

--- a/qesource/extensions/rend/rend.h
+++ b/qesource/extensions/rend/rend.h
@@ -43,7 +43,7 @@ public:
   singlelinestream(istream& in, option opt = none)
   {
     string s = "";
-    char c = in.get(); if (opt == skipleadingws) while(c != EOF && isspace(c)) c = in.get();
+    signed char c = in.get(); if (opt == skipleadingws) while(c != EOF && isspace(c)) c = in.get();
     while(c != '\n' && c != EOF) { s += c; c = in.get(); }
     str(s);
   }

--- a/qesource/source/convenientstreams.h
+++ b/qesource/source/convenientstreams.h
@@ -26,7 +26,7 @@ public:
   slwcistream(istream& in, option opt = none)
   {
     string s = "";
-    char c = in.get(); 
+    signed char c = in.get();
     if (opt == skipleadingws) 
       while(c != EOF && (isspace(c) || c == '\\' && isspace(in.peek()))) c = in.get();
     // States  : 0 = normal, 1 = in comment, 2 = just read a backslash
@@ -88,7 +88,7 @@ cacInBuff::int_type cacInBuff::underflow()
     // States  : 0 = normal, 1 = in comment, 2 = just read a backslash
     istream & in = *trueIn;
     int state = 0;
-    char c;
+    signed char c;
     while(ls < buffSize - extra && (c = in.get()))
     {
       if (c == EOF) break;

--- a/qesource/source/db/convenientstreams.h
+++ b/qesource/source/db/convenientstreams.h
@@ -29,7 +29,7 @@ public:
   slwcistream(istream& in, option opt = none)
   {
     string s = "";
-    char c = in.get(); 
+    signed char c = in.get();
     if (opt == skipleadingws) 
       while(c != EOF && (isspace(c) || c == '\\' && isspace(in.peek()))) c = in.get();
     // States  : 0 = normal, 1 = in comment, 2 = just read a backslash
@@ -92,7 +92,7 @@ cacInBuff::int_type cacInBuff::underflow()
     // States  : 0 = normal, 1 = in comment, 2 = just read a backslash
     istream & in = *trueIn;
     int state = 0;
-    char c;
+    signed char c;
     while(ls < buffSize - extra && (c = in.get()))
     {
       if (c == EOF) break;


### PR DESCRIPTION
Otherwise, EOF will be read as 255 instead of -1 on architectures that default
to unsigned chars (e.g., ARM and PowerPC).

Bug: https://bugs.debian.org/996561